### PR TITLE
Fixed issue #9

### DIFF
--- a/src/load.ts
+++ b/src/load.ts
@@ -3,7 +3,7 @@ import { GraphQLClient, request } from 'graphql-request';
 
 import * as papa from 'papaparse';
 
-import * as chalk from 'chalk';
+import chalk from 'chalk';
 import * as path from 'path';
 import * as fs from 'fs';
 
@@ -37,6 +37,7 @@ export const builder = {
 };
 
 function getSchema(config) {
+  console.log("At getSchema the config parameter is: " + JSON.stringify(config))
   const schemaPath = config.schemaPath;
   const schemaContents = fs.readFileSync(schemaPath).toString();
   return buildASTSchema(parse(schemaContents));
@@ -100,7 +101,9 @@ function getMutation(config, argv) {
   }
   const fields = mutationType.getFields();
   const mutationName = argv.mutation || options.mutation;
+  // console.log("mutationName at getMutation is " + mutationName)
   const mutationField = fields[mutationName];
+  // console.log(chalk.red("mutationField at getMutation is " + JSON.stringify(mutationField)))
   if (!mutationField) {
     return console.log(chalk.red(`Mutation for "${mutationName}" not found.`));
   }
@@ -109,26 +112,39 @@ function getMutation(config, argv) {
 }
 
 function findReturnExpression(mutationField) {
+    // console.log(chalk.yellow("At findReturnExpression, the mutationField is " + JSON.stringify(mutationField)))
     const returnType = getNamedType(mutationField.type)
     if (returnType instanceof GraphQLObjectType) {
        const fields = (returnType as GraphQLObjectType).getFields();
        const field = Object.keys(fields).find((x) => (getNamedType(fields[x].type) === GraphQLID)) || Object.keys(fields)[0]
-       return `{ ${field} }`
+       // console.log("field at findReturnExpression is: " + field)
+	return `{ ${field} }`
     }
     return "";
 }
 
 function buildMutations(mutationField, args, data, mapping,delim) {
+  // console.log("\n mutationField parameter at buildMutations is " + JSON.stringify(mutationField))
+  // console.log("\n args parameter at buildMutations is " + JSON.stringify( args))
   const rMapping = {};
   const regexp = new RegExp(delim + "\s*");
   Object.keys(mapping).forEach((k) => rMapping[mapping[k]]=k);
+  console.log("While mapping is " + JSON.stringify(mapping) + " , but rMapping is " + JSON.stringify(rMapping))
   const mutations = 
   data.map((row,idx) => {
+    console.log("\n row when it was declared is: " + JSON.stringify(row))
     var fullfilled = true;
     const params = Object.keys(args).map( (key) => { 
       const arg = args[key];
-      const column=(rMapping[key]||key).toString();
+      // console.log(chalk.white("At buildMutations, the arg inside data.map is " + JSON.stringify(arg)))
+      // console.log("arg.name inside data.map at getMutation is " + arg.name)
+     //  const column=(rMapping[key]||key).toString(); // original
+      console.log("Correcting the key mapping data with const column =  mapping[key].toString() is " + (mapping[key]).toString())
+      const column = mapping[key].toString()
+      console.log("\n At data.map in buildMutations key is: "+ key + " and rMapping is: "+ JSON.stringify(rMapping))
       // todo params
+      console.log("When naming the values, we use row[column] where column is: " + column)
+      // console.log("Alternatively testing, we can also find out what row[key] is " + row["episode"])
       var value=row[column]; // sometimes this is not wanted, e.g. if there is a crossover naming // || row[key]
       const type = arg.type.toString();
       const namedType = getNamedType(arg.type).name;
@@ -136,7 +152,8 @@ function buildMutations(mutationField, args, data, mapping,delim) {
       const isNonNull = type.charAt(type.length -1 ) == '!';
       if (value === null || value === undefined) {
          if (isNonNull) fullfilled = false;
-         return null;
+         	console.log("At data.map in buildMutations if value === null || undefined, value is: " + value)
+		return null;
       }
       if (isList) {
          if (!Array.isArray(value)) {
@@ -152,12 +169,14 @@ function buildMutations(mutationField, args, data, mapping,delim) {
       } else if (namedType == "String" || namedType == "ID" ) {
          value=JSON.stringify(value.toString());
       }
+      console.log("return arg.name" + arg.name + " : value " + value + " in data.map at buildMutations")
       return `${arg.name}: ${value}`;
     }).filter((v) => v !== null).join(",");
     const returnExpression = findReturnExpression(mutationField);
+    console.log("\n returnExpression at data.map at buildMutations returns: " + returnExpression)
     return fullfilled ? `_${idx} : ${mutationField.name} ( ${params} ) ${returnExpression}` : null;
   }).filter((v) => v !== null).join("\n");
-
+  console.log("\n buildMutations returns: " + mutations)
   return "mutation { \n" + mutations +"\n}";  
 }
 
@@ -170,6 +189,7 @@ function parseJson(str) {
 }
 
 exports.handler = async function (context, argv) {
+  console.log("Graphql-load has been invoked")
   const config = await context.getProjectConfig()
   const schema = config.getSchemaSDL();
   const configPath = config.configPath
@@ -188,12 +208,14 @@ exports.handler = async function (context, argv) {
 
   const data = readFile(path.dirname(configPath), options, argv);
   const mapping = parseJson(argv.mapping||"null") || options.mapping || {};
+
   if (Object.keys(mapping).length > 0) {
      console.log(chalk.yellow(`Using mapping: ${JSON.stringify(mapping)}`));
   }
   const delim = argv.delim || ';';
   const mutations = buildMutations(mutationField, args, data, mapping, delim);
-
+  console.log("mutations at mainWorkflow is " + mutations)
+  console.log("Let's see if the error is " + mutations.substring(0,200))
   console.log(chalk.yellow(`Sending query:\n${mutations.substring(0,200)}...`));
   const client = new GraphQLClient(endpoint.url, endpoint);
   const result = await client.request(mutations, {});

--- a/src/load.ts
+++ b/src/load.ts
@@ -124,27 +124,27 @@ function findReturnExpression(mutationField) {
 }
 
 function buildMutations(mutationField, args, data, mapping,delim) {
-  // console.log("\n mutationField parameter at buildMutations is " + JSON.stringify(mutationField))
-  // console.log("\n args parameter at buildMutations is " + JSON.stringify( args))
+
+
   const rMapping = {};
   const regexp = new RegExp(delim + "\s*");
   Object.keys(mapping).forEach((k) => rMapping[mapping[k]]=k);
-  console.log("While mapping is " + JSON.stringify(mapping) + " , but rMapping is " + JSON.stringify(rMapping))
+
   const mutations = 
   data.map((row,idx) => {
-    console.log("\n row when it was declared is: " + JSON.stringify(row))
+
     var fullfilled = true;
     const params = Object.keys(args).map( (key) => { 
       const arg = args[key];
-      // console.log(chalk.white("At buildMutations, the arg inside data.map is " + JSON.stringify(arg)))
-      // console.log("arg.name inside data.map at getMutation is " + arg.name)
-     //  const column=(rMapping[key]||key).toString(); // original
-      console.log("Correcting the key mapping data with const column =  mapping[key].toString() is " + (mapping[key]).toString())
+
+
+      //  const column=(rMapping[key]||key).toString(); // original
+      //  console.log("Correcting the key mapping data with const column =  mapping[key].toString() is " + (mapping[key]).toString())
       const column = mapping[key].toString()
       console.log("\n At data.map in buildMutations key is: "+ key + " and rMapping is: "+ JSON.stringify(rMapping))
       // todo params
       console.log("When naming the values, we use row[column] where column is: " + column)
-      // console.log("Alternatively testing, we can also find out what row[key] is " + row["episode"])
+
       var value=row[column]; // sometimes this is not wanted, e.g. if there is a crossover naming // || row[key]
       const type = arg.type.toString();
       const namedType = getNamedType(arg.type).name;
@@ -152,7 +152,7 @@ function buildMutations(mutationField, args, data, mapping,delim) {
       const isNonNull = type.charAt(type.length -1 ) == '!';
       if (value === null || value === undefined) {
          if (isNonNull) fullfilled = false;
-         	console.log("At data.map in buildMutations if value === null || undefined, value is: " + value)
+
 		return null;
       }
       if (isList) {
@@ -169,14 +169,14 @@ function buildMutations(mutationField, args, data, mapping,delim) {
       } else if (namedType == "String" || namedType == "ID" ) {
          value=JSON.stringify(value.toString());
       }
-      console.log("return arg.name" + arg.name + " : value " + value + " in data.map at buildMutations")
+
       return `${arg.name}: ${value}`;
     }).filter((v) => v !== null).join(",");
     const returnExpression = findReturnExpression(mutationField);
-    console.log("\n returnExpression at data.map at buildMutations returns: " + returnExpression)
+
     return fullfilled ? `_${idx} : ${mutationField.name} ( ${params} ) ${returnExpression}` : null;
   }).filter((v) => v !== null).join("\n");
-  console.log("\n buildMutations returns: " + mutations)
+
   return "mutation { \n" + mutations +"\n}";  
 }
 
@@ -189,7 +189,7 @@ function parseJson(str) {
 }
 
 exports.handler = async function (context, argv) {
-  console.log("Graphql-load has been invoked")
+
   const config = await context.getProjectConfig()
   const schema = config.getSchemaSDL();
   const configPath = config.configPath
@@ -214,8 +214,8 @@ exports.handler = async function (context, argv) {
   }
   const delim = argv.delim || ';';
   const mutations = buildMutations(mutationField, args, data, mapping, delim);
-  console.log("mutations at mainWorkflow is " + mutations)
-  console.log("Let's see if the error is " + mutations.substring(0,200))
+
+
   console.log(chalk.yellow(`Sending query:\n${mutations.substring(0,200)}...`));
   const client = new GraphQLClient(endpoint.url, endpoint);
   const result = await client.request(mutations, {});

--- a/src/load.ts
+++ b/src/load.ts
@@ -126,9 +126,9 @@ function findReturnExpression(mutationField) {
 function buildMutations(mutationField, args, data, mapping,delim) {
 
 
-  const rMapping = {};
+  // const rMapping = {}; // unnecessary given direct mapping is used
   const regexp = new RegExp(delim + "\s*");
-  Object.keys(mapping).forEach((k) => rMapping[mapping[k]]=k);
+  // Object.keys(mapping).forEach((k) => rMapping[mapping[k]]=k); // unnecessary given direct mapping is used
 
   const mutations = 
   data.map((row,idx) => {


### PR DESCRIPTION
As described in [this issue #9 ](https://github.com/neo4j-graphql/graphql-cli-load/issues/9), I was trying to run this command in the most minimal Prisma example which I created [here](https://github.com/daquintero/graphql-cli-load/tree/prismaExample/prismaExample): 
```
graphql load --csv reviews.txt --mutation corruptionIn --mapping '{ "url" : "commentary", "description" : "stars"}'
```

With the original graphql-cli-load code, I got this error:
```
✖ 
Syntax Error: Expected Name, found }: {"response":{"errors":[{"message":"Syntax Error: Expected Name, found }","locations":[{"line":3,"column":1}]}],"status":400},"request":{"query":"mutation { \n\n}","variables":{}}}
```
 
After a lot of research into your source code, I recognized the syntax error was because there was no mapped mutations being built inside `buildMutations`, and then saw that the `rMapping` was calling the wrong "key" to select the `values` from the given csv `rows`. Changing this to the original `mapping`, the whole graphql-cli-load worked properly. 